### PR TITLE
Use env secret in authController

### DIFF
--- a/authController.js
+++ b/authController.js
@@ -8,7 +8,7 @@ const nodemailer = require('nodemailer');
 require('dotenv').config();
 
 const usuariosPath = path.join(__dirname, 'usuarios.json');
-const SECRET = 'chave-secreta-do-token';
+const SECRET = process.env.JWT_SECRET || 'chave-super-secreta-qrcerto';
 
 // ========== UTILITÁRIOS ==========
 const lerUsuarios = () => {


### PR DESCRIPTION
## Summary
- use `process.env.JWT_SECRET` fallback for authController's JWT secret
- verify JWT operations use the new constant

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f197e25388320b77dab71d944ee90